### PR TITLE
maxwell_3d: Restructure macro upload to use a single macro code memory.

### DIFF
--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -475,12 +475,13 @@ public:
                 INSERT_PADDING_WORDS(0x45);
 
                 struct {
-                    INSERT_PADDING_WORDS(1);
+                    u32 upload_address;
                     u32 data;
                     u32 entry;
+                    u32 bind;
                 } macros;
 
-                INSERT_PADDING_WORDS(0x189);
+                INSERT_PADDING_WORDS(0x188);
 
                 u32 tfb_enabled;
 
@@ -994,12 +995,28 @@ public:
     /// Returns the texture information for a specific texture in a specific shader stage.
     Texture::FullTextureInfo GetStageTexture(Regs::ShaderStage stage, std::size_t offset) const;
 
+    /// Memory for macro code - it's undetermined how big this is, however 1MB is much larger than
+    /// we've seen used.
+    using MacroMemory = std::array<u32, 0x40000>;
+
+    /// Gets a reference to macro memory.
+    const MacroMemory& GetMacroMemory() const {
+        return macro_memory;
+    }
+
 private:
     void InitializeRegisterDefaults();
 
     VideoCore::RasterizerInterface& rasterizer;
 
-    std::unordered_map<u32, std::vector<u32>> uploaded_macros;
+    static constexpr std::size_t MACRO_COUNT{0x80};
+    static constexpr std::size_t MACRO_MASK{MACRO_COUNT - 1};
+
+    /// Start offsets of each macro in macro_memory
+    std::array<u32, MACRO_COUNT> macro_offsets;
+
+    /// Memory for macro code
+    MacroMemory macro_memory;
 
     /// Macro method that is currently being executed / being fed parameters.
     u32 executing_macro = 0;
@@ -1022,8 +1039,11 @@ private:
      */
     void CallMacroMethod(u32 method, std::vector<u32> parameters);
 
-    /// Handles writes to the macro uploading registers.
+    /// Handles writes to the macro uploading register.
     void ProcessMacroUpload(u32 data);
+
+    /// Handles writes to the macro bind register.
+    void ProcessMacroBind(u32 data);
 
     /// Handles a write to the CLEAR_BUFFERS register.
     void ProcessClearBuffers();

--- a/src/video_core/macro_interpreter.h
+++ b/src/video_core/macro_interpreter.h
@@ -21,10 +21,10 @@ public:
 
     /**
      * Executes the macro code with the specified input parameters.
-     * @param code The macro byte code to execute
-     * @param parameters The parameters of the macro
+     * @param offset Offset to start execution at.
+     * @param parameters The parameters of the macro.
      */
-    void Execute(const std::vector<u32>& code, std::vector<u32> parameters);
+    void Execute(u32 offset, std::vector<u32> parameters);
 
 private:
     enum class Operation : u32 {
@@ -109,11 +109,11 @@ private:
     /**
      * Executes a single macro instruction located at the current program counter. Returns whether
      * the interpreter should keep running.
-     * @param code The macro code to execute.
+     * @param offset Offset to start execution at.
      * @param is_delay_slot Whether the current step is being executed due to a delay slot in a
      * previous instruction.
      */
-    bool Step(const std::vector<u32>& code, bool is_delay_slot);
+    bool Step(u32 offset, bool is_delay_slot);
 
     /// Calculates the result of an ALU operation. src_a OP src_b;
     u32 GetALUResult(ALUOperation operation, u32 src_a, u32 src_b) const;
@@ -126,7 +126,7 @@ private:
     bool EvaluateBranchCondition(BranchCondition cond, u32 value) const;
 
     /// Reads an opcode at the current program counter location.
-    Opcode GetOpcode(const std::vector<u32>& code) const;
+    Opcode GetOpcode(u32 offset) const;
 
     /// Returns the specified register's value. Register 0 is hardcoded to always return 0.
     u32 GetRegister(u32 register_id) const;


### PR DESCRIPTION
- Fixes an issue where macros could be skipped.
- Fixes rendering of distant objects in Super Mario Odyssey.