### PR TITLE
Ability to switch between docked and undocked mode in-game

### DIFF
--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include <queue>
 #include "core/hle/service/service.h"
 
 namespace Kernel {
@@ -37,6 +38,31 @@ enum SystemLanguage {
     // 4.0.0+
     SimplifiedChinese = 15,
     TraditionalChinese = 16,
+};
+
+class AppletMessageQueue {
+public:
+    enum class AppletMessage : u32 {
+        NoMessage = 0,
+        FocusStateChanged = 15,
+        OperationModeChanged = 30,
+        PerformanceModeChanged = 31,
+    };
+
+    AppletMessageQueue();
+    ~AppletMessageQueue();
+
+    const Kernel::SharedPtr<Kernel::Event>& GetMesssageRecieveEvent() const;
+    const Kernel::SharedPtr<Kernel::Event>& GetOperationModeChangedEvent() const;
+    void PushMessage(AppletMessage msg);
+    AppletMessage PopMessage();
+    std::size_t GetMessageCount() const;
+    void OperationModeChanged();
+
+private:
+    std::queue<AppletMessage> messages{};
+    Kernel::SharedPtr<Kernel::Event> on_new_message;
+    Kernel::SharedPtr<Kernel::Event> on_operation_mode_changed;
 };
 
 class IWindowController final : public ServiceFramework<IWindowController> {
@@ -102,7 +128,7 @@ private:
 
 class ICommonStateGetter final : public ServiceFramework<ICommonStateGetter> {
 public:
-    ICommonStateGetter();
+    explicit ICommonStateGetter(std::shared_ptr<AppletMessageQueue> msg_queue);
     ~ICommonStateGetter() override;
 
 private:
@@ -126,6 +152,7 @@ private:
     void GetDefaultDisplayResolution(Kernel::HLERequestContext& ctx);
 
     Kernel::SharedPtr<Kernel::Event> event;
+    std::shared_ptr<AppletMessageQueue> msg_queue;
 };
 
 class ILibraryAppletCreator final : public ServiceFramework<ILibraryAppletCreator> {

--- a/src/core/hle/service/am/applet_ae.h
+++ b/src/core/hle/service/am/applet_ae.h
@@ -17,8 +17,11 @@ namespace AM {
 
 class AppletAE final : public ServiceFramework<AppletAE> {
 public:
-    explicit AppletAE(std::shared_ptr<NVFlinger::NVFlinger> nvflinger);
+    explicit AppletAE(std::shared_ptr<NVFlinger::NVFlinger> nvflinger,
+                      std::shared_ptr<AppletMessageQueue> msg_queue);
     ~AppletAE() override;
+
+    const std::shared_ptr<AppletMessageQueue>& GetMessageQueue() const;
 
 private:
     void OpenSystemAppletProxy(Kernel::HLERequestContext& ctx);
@@ -26,6 +29,7 @@ private:
     void OpenLibraryAppletProxyOld(Kernel::HLERequestContext& ctx);
 
     std::shared_ptr<NVFlinger::NVFlinger> nvflinger;
+    std::shared_ptr<AppletMessageQueue> msg_queue;
 };
 
 } // namespace AM

--- a/src/core/hle/service/am/applet_oe.h
+++ b/src/core/hle/service/am/applet_oe.h
@@ -17,13 +17,17 @@ namespace AM {
 
 class AppletOE final : public ServiceFramework<AppletOE> {
 public:
-    explicit AppletOE(std::shared_ptr<NVFlinger::NVFlinger> nvflinger);
+    explicit AppletOE(std::shared_ptr<NVFlinger::NVFlinger> nvflinger,
+                      std::shared_ptr<AppletMessageQueue> msg_queue);
     ~AppletOE() override;
+
+    const std::shared_ptr<AppletMessageQueue>& GetMessageQueue() const;
 
 private:
     void OpenApplicationProxy(Kernel::HLERequestContext& ctx);
 
     std::shared_ptr<NVFlinger::NVFlinger> nvflinger;
+    std::shared_ptr<AppletMessageQueue> msg_queue;
 };
 
 } // namespace AM

--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -3,6 +3,10 @@
 // Refer to the license.txt file included.
 
 #include "core/core.h"
+#include "core/hle/service/am/am.h"
+#include "core/hle/service/am/applet_ae.h"
+#include "core/hle/service/am/applet_oe.h"
+#include "core/hle/service/sm/sm.h"
 #include "core/settings.h"
 #include "ui_configure_general.h"
 #include "yuzu/configuration/configure_general.h"
@@ -20,7 +24,6 @@ ConfigureGeneral::ConfigureGeneral(QWidget* parent)
     this->setConfiguration();
 
     ui->use_cpu_jit->setEnabled(!Core::System::GetInstance().IsPoweredOn());
-    ui->use_docked_mode->setEnabled(!Core::System::GetInstance().IsPoweredOn());
 }
 
 ConfigureGeneral::~ConfigureGeneral() = default;
@@ -45,6 +48,27 @@ void ConfigureGeneral::applyConfiguration() {
         ui->theme_combobox->itemData(ui->theme_combobox->currentIndex()).toString();
 
     Settings::values.use_cpu_jit = ui->use_cpu_jit->isChecked();
+    const bool pre_docked_mode = Settings::values.use_docked_mode;
     Settings::values.use_docked_mode = ui->use_docked_mode->isChecked();
+
+    if (pre_docked_mode != Settings::values.use_docked_mode) {
+        Core::System& system{Core::System::GetInstance()};
+        Service::SM::ServiceManager& sm = system.ServiceManager();
+
+        // Message queue is shared between these services, we just need to signal an operation
+        // change to one and it will handle both automatically
+        auto applet_oe = sm.GetService<Service::AM::AppletOE>("appletOE");
+        auto applet_ae = sm.GetService<Service::AM::AppletAE>("appletAE");
+        bool has_signalled = false;
+
+        if (applet_oe != nullptr) {
+            applet_oe->GetMessageQueue()->OperationModeChanged();
+            has_signalled = true;
+        }
+
+        if (applet_ae != nullptr && !has_signalled) {
+            applet_ae->GetMessageQueue()->OperationModeChanged();
+        }
+    }
     Settings::values.enable_nfc = ui->enable_nfc->isChecked();
 }


### PR DESCRIPTION
Started implementation of the AM message queue mainly used in state getters. Added the ability to switch docked mode whilst in game without stopping emulation. Also removed some things which shouldn't be labelled as stubs as they're implemented correctly