### PR TITLE
core: Relocate CPU core management to its own class

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -12,6 +12,8 @@ add_library(core STATIC
     core_timing.h
     core_timing_util.cpp
     core_timing_util.h
+    cpu_core_manager.cpp
+    cpu_core_manager.h
     crypto/aes_util.cpp
     crypto/aes_util.h
     crypto/encryption_layer.cpp

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -14,6 +14,7 @@
 #include "core/core.h"
 #include "core/core_cpu.h"
 #include "core/core_timing.h"
+#include "core/cpu_core_manager.h"
 #include "core/file_sys/mode.h"
 #include "core/file_sys/vfs_concat.h"
 #include "core/file_sys/vfs_real.h"
@@ -28,7 +29,6 @@
 #include "core/hle/service/sm/sm.h"
 #include "core/loader/loader.h"
 #include "core/perf_stats.h"
-#include "core/settings.h"
 #include "core/telemetry_session.h"
 #include "frontend/applets/software_keyboard.h"
 #include "video_core/debug_utils/debug_utils.h"
@@ -71,64 +71,22 @@ FileSys::VirtualFile GetGameFileFromPath(const FileSys::VirtualFilesystem& vfs,
 
     return vfs->OpenFile(path, FileSys::Mode::Read);
 }
-
-/// Runs a CPU core while the system is powered on
-void RunCpuCore(Cpu& cpu_state) {
-    while (Core::System::GetInstance().IsPoweredOn()) {
-        cpu_state.RunLoop(true);
-    }
-}
 } // Anonymous namespace
 
 struct System::Impl {
     Cpu& CurrentCpuCore() {
-        if (Settings::values.use_multi_core) {
-            const auto& search = thread_to_cpu.find(std::this_thread::get_id());
-            ASSERT(search != thread_to_cpu.end());
-            ASSERT(search->second);
-            return *search->second;
-        }
-
-        // Otherwise, use single-threaded mode active_core variable
-        return *cpu_cores[active_core];
+        return cpu_core_manager.GetCurrentCore();
     }
 
     ResultStatus RunLoop(bool tight_loop) {
         status = ResultStatus::Success;
 
-        // Update thread_to_cpu in case Core 0 is run from a different host thread
-        thread_to_cpu[std::this_thread::get_id()] = cpu_cores[0].get();
-
-        if (GDBStub::IsServerEnabled()) {
-            GDBStub::HandlePacket();
-
-            // If the loop is halted and we want to step, use a tiny (1) number of instructions to
-            // execute. Otherwise, get out of the loop function.
-            if (GDBStub::GetCpuHaltFlag()) {
-                if (GDBStub::GetCpuStepFlag()) {
-                    tight_loop = false;
-                } else {
-                    return ResultStatus::Success;
-                }
-            }
-        }
-
-        for (active_core = 0; active_core < NUM_CPU_CORES; ++active_core) {
-            cpu_cores[active_core]->RunLoop(tight_loop);
-            if (Settings::values.use_multi_core) {
-                // Cores 1-3 are run on other threads in this mode
-                break;
-            }
-        }
-
-        if (GDBStub::IsServerEnabled()) {
-            GDBStub::SetCpuStepFlag(false);
-        }
+        cpu_core_manager.RunLoop(tight_loop);
 
         return status;
     }
 
-    ResultStatus Init(Frontend::EmuWindow& emu_window) {
+    ResultStatus Init(System& system, Frontend::EmuWindow& emu_window) {
         LOG_DEBUG(HW_Memory, "initialized OK");
 
         CoreTiming::Init();
@@ -145,12 +103,6 @@ struct System::Impl {
         auto main_process = Kernel::Process::Create(kernel, "main");
         kernel.MakeCurrentProcess(main_process.get());
 
-        cpu_barrier = std::make_unique<CpuBarrier>();
-        cpu_exclusive_monitor = Cpu::MakeExclusiveMonitor(cpu_cores.size());
-        for (std::size_t index = 0; index < cpu_cores.size(); ++index) {
-            cpu_cores[index] = std::make_unique<Cpu>(*cpu_exclusive_monitor, *cpu_barrier, index);
-        }
-
         telemetry_session = std::make_unique<Core::TelemetrySession>();
         service_manager = std::make_shared<Service::SM::ServiceManager>();
 
@@ -164,17 +116,8 @@ struct System::Impl {
 
         gpu_core = std::make_unique<Tegra::GPU>(renderer->Rasterizer());
 
-        // Create threads for CPU cores 1-3, and build thread_to_cpu map
-        // CPU core 0 is run on the main thread
-        thread_to_cpu[std::this_thread::get_id()] = cpu_cores[0].get();
-        if (Settings::values.use_multi_core) {
-            for (std::size_t index = 0; index < cpu_core_threads.size(); ++index) {
-                cpu_core_threads[index] =
-                    std::make_unique<std::thread>(RunCpuCore, std::ref(*cpu_cores[index + 1]));
-                thread_to_cpu[cpu_core_threads[index]->get_id()] = cpu_cores[index + 1].get();
-            }
-        }
-
+        cpu_core_manager.Initialize(system);
+        is_powered_on = true;
         LOG_DEBUG(Core, "Initialized OK");
 
         // Reset counters and set time origin to current frame
@@ -184,7 +127,8 @@ struct System::Impl {
         return ResultStatus::Success;
     }
 
-    ResultStatus Load(Frontend::EmuWindow& emu_window, const std::string& filepath) {
+    ResultStatus Load(System& system, Frontend::EmuWindow& emu_window,
+                      const std::string& filepath) {
         app_loader = Loader::GetLoader(GetGameFileFromPath(virtual_filesystem, filepath));
 
         if (!app_loader) {
@@ -201,7 +145,7 @@ struct System::Impl {
             return ResultStatus::ErrorSystemMode;
         }
 
-        ResultStatus init_result{Init(emu_window)};
+        ResultStatus init_result{Init(system, emu_window)};
         if (init_result != ResultStatus::Success) {
             LOG_CRITICAL(Core, "Failed to initialize system (Error {})!",
                          static_cast<int>(init_result));
@@ -231,6 +175,8 @@ struct System::Impl {
         Telemetry().AddField(Telemetry::FieldType::Performance, "Shutdown_Frametime",
                              perf_results.frametime * 1000.0);
 
+        is_powered_on = false;
+
         // Shutdown emulation session
         renderer.reset();
         GDBStub::Shutdown();
@@ -240,19 +186,7 @@ struct System::Impl {
         gpu_core.reset();
 
         // Close all CPU/threading state
-        cpu_barrier->NotifyEnd();
-        if (Settings::values.use_multi_core) {
-            for (auto& thread : cpu_core_threads) {
-                thread->join();
-                thread.reset();
-            }
-        }
-        thread_to_cpu.clear();
-        for (auto& cpu_core : cpu_cores) {
-            cpu_core.reset();
-        }
-        cpu_exclusive_monitor.reset();
-        cpu_barrier.reset();
+        cpu_core_manager.Shutdown();
 
         // Shutdown kernel and core timing
         kernel.Shutdown();
@@ -289,11 +223,8 @@ struct System::Impl {
     std::unique_ptr<VideoCore::RendererBase> renderer;
     std::unique_ptr<Tegra::GPU> gpu_core;
     std::shared_ptr<Tegra::DebugContext> debug_context;
-    std::unique_ptr<ExclusiveMonitor> cpu_exclusive_monitor;
-    std::unique_ptr<CpuBarrier> cpu_barrier;
-    std::array<std::unique_ptr<Cpu>, NUM_CPU_CORES> cpu_cores;
-    std::array<std::unique_ptr<std::thread>, NUM_CPU_CORES - 1> cpu_core_threads;
-    std::size_t active_core{}; ///< Active core, only used in single thread mode
+    CpuCoreManager cpu_core_manager;
+    bool is_powered_on = false;
 
     /// Frontend applets
     std::unique_ptr<Core::Frontend::SoftwareKeyboardApplet> software_keyboard;
@@ -306,9 +237,6 @@ struct System::Impl {
 
     ResultStatus status = ResultStatus::Success;
     std::string status_details = "";
-
-    /// Map of guest threads to CPU cores
-    std::map<std::thread::id, Cpu*> thread_to_cpu;
 
     Core::PerfStats perf_stats;
     Core::FrameLimiter frame_limiter;
@@ -334,17 +262,15 @@ System::ResultStatus System::SingleStep() {
 }
 
 void System::InvalidateCpuInstructionCaches() {
-    for (auto& cpu : impl->cpu_cores) {
-        cpu->ArmInterface().ClearInstructionCache();
-    }
+    impl->cpu_core_manager.InvalidateAllInstructionCaches();
 }
 
 System::ResultStatus System::Load(Frontend::EmuWindow& emu_window, const std::string& filepath) {
-    return impl->Load(emu_window, filepath);
+    return impl->Load(*this, emu_window, filepath);
 }
 
 bool System::IsPoweredOn() const {
-    return impl->cpu_barrier && impl->cpu_barrier->IsAlive();
+    return impl->is_powered_on;
 }
 
 void System::PrepareReschedule() {
@@ -408,21 +334,20 @@ const ARM_Interface& System::ArmInterface(std::size_t core_index) const {
 }
 
 Cpu& System::CpuCore(std::size_t core_index) {
-    ASSERT(core_index < NUM_CPU_CORES);
-    return *impl->cpu_cores[core_index];
+    return impl->cpu_core_manager.GetCore(core_index);
 }
 
 const Cpu& System::CpuCore(std::size_t core_index) const {
     ASSERT(core_index < NUM_CPU_CORES);
-    return *impl->cpu_cores[core_index];
+    return impl->cpu_core_manager.GetCore(core_index);
 }
 
 ExclusiveMonitor& System::Monitor() {
-    return *impl->cpu_exclusive_monitor;
+    return impl->cpu_core_manager.GetExclusiveMonitor();
 }
 
 const ExclusiveMonitor& System::Monitor() const {
-    return *impl->cpu_exclusive_monitor;
+    return impl->cpu_core_manager.GetExclusiveMonitor();
 }
 
 Tegra::GPU& System::GPU() {
@@ -506,7 +431,7 @@ const Core::Frontend::SoftwareKeyboardApplet& System::GetSoftwareKeyboard() cons
 }
 
 System::ResultStatus System::Init(Frontend::EmuWindow& emu_window) {
-    return impl->Init(emu_window);
+    return impl->Init(*this, emu_window);
 }
 
 void System::Shutdown() {

--- a/src/core/cpu_core_manager.cpp
+++ b/src/core/cpu_core_manager.cpp
@@ -1,0 +1,142 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/assert.h"
+#include "core/arm/exclusive_monitor.h"
+#include "core/core.h"
+#include "core/core_cpu.h"
+#include "core/cpu_core_manager.h"
+#include "core/gdbstub/gdbstub.h"
+#include "core/settings.h"
+
+namespace Core {
+namespace {
+void RunCpuCore(const System& system, Cpu& cpu_state) {
+    while (system.IsPoweredOn()) {
+        cpu_state.RunLoop(true);
+    }
+}
+} // Anonymous namespace
+
+CpuCoreManager::CpuCoreManager() = default;
+CpuCoreManager::~CpuCoreManager() = default;
+
+void CpuCoreManager::Initialize(System& system) {
+    barrier = std::make_unique<CpuBarrier>();
+    exclusive_monitor = Cpu::MakeExclusiveMonitor(cores.size());
+
+    for (std::size_t index = 0; index < cores.size(); ++index) {
+        cores[index] = std::make_unique<Cpu>(*exclusive_monitor, *barrier, index);
+    }
+
+    // Create threads for CPU cores 1-3, and build thread_to_cpu map
+    // CPU core 0 is run on the main thread
+    thread_to_cpu[std::this_thread::get_id()] = cores[0].get();
+    if (!Settings::values.use_multi_core) {
+        return;
+    }
+
+    for (std::size_t index = 0; index < core_threads.size(); ++index) {
+        core_threads[index] = std::make_unique<std::thread>(RunCpuCore, std::cref(system),
+                                                            std::ref(*cores[index + 1]));
+        thread_to_cpu[core_threads[index]->get_id()] = cores[index + 1].get();
+    }
+}
+
+void CpuCoreManager::Shutdown() {
+    barrier->NotifyEnd();
+    if (Settings::values.use_multi_core) {
+        for (auto& thread : core_threads) {
+            thread->join();
+            thread.reset();
+        }
+    }
+
+    thread_to_cpu.clear();
+    for (auto& cpu_core : cores) {
+        cpu_core.reset();
+    }
+
+    exclusive_monitor.reset();
+    barrier.reset();
+}
+
+Cpu& CpuCoreManager::GetCore(std::size_t index) {
+    return *cores.at(index);
+}
+
+const Cpu& CpuCoreManager::GetCore(std::size_t index) const {
+    return *cores.at(index);
+}
+
+ExclusiveMonitor& CpuCoreManager::GetExclusiveMonitor() {
+    return *exclusive_monitor;
+}
+
+const ExclusiveMonitor& CpuCoreManager::GetExclusiveMonitor() const {
+    return *exclusive_monitor;
+}
+
+Cpu& CpuCoreManager::GetCurrentCore() {
+    if (Settings::values.use_multi_core) {
+        const auto& search = thread_to_cpu.find(std::this_thread::get_id());
+        ASSERT(search != thread_to_cpu.end());
+        ASSERT(search->second);
+        return *search->second;
+    }
+
+    // Otherwise, use single-threaded mode active_core variable
+    return *cores[active_core];
+}
+
+const Cpu& CpuCoreManager::GetCurrentCore() const {
+    if (Settings::values.use_multi_core) {
+        const auto& search = thread_to_cpu.find(std::this_thread::get_id());
+        ASSERT(search != thread_to_cpu.end());
+        ASSERT(search->second);
+        return *search->second;
+    }
+
+    // Otherwise, use single-threaded mode active_core variable
+    return *cores[active_core];
+}
+
+void CpuCoreManager::RunLoop(bool tight_loop) {
+    // Update thread_to_cpu in case Core 0 is run from a different host thread
+    thread_to_cpu[std::this_thread::get_id()] = cores[0].get();
+
+    if (GDBStub::IsServerEnabled()) {
+        GDBStub::HandlePacket();
+
+        // If the loop is halted and we want to step, use a tiny (1) number of instructions to
+        // execute. Otherwise, get out of the loop function.
+        if (GDBStub::GetCpuHaltFlag()) {
+            if (GDBStub::GetCpuStepFlag()) {
+                tight_loop = false;
+            } else {
+                return;
+            }
+        }
+    }
+
+    for (active_core = 0; active_core < NUM_CPU_CORES; ++active_core) {
+        cores[active_core]->RunLoop(tight_loop);
+        if (Settings::values.use_multi_core) {
+            // Cores 1-3 are run on other threads in this mode
+            break;
+        }
+    }
+
+    if (GDBStub::IsServerEnabled()) {
+        GDBStub::SetCpuStepFlag(false);
+    }
+}
+
+void CpuCoreManager::InvalidateAllInstructionCaches() {
+    for (auto& cpu : cores) {
+        cpu->ArmInterface().ClearInstructionCache();
+    }
+}
+
+} // namespace Core

--- a/src/core/cpu_core_manager.h
+++ b/src/core/cpu_core_manager.h
@@ -1,0 +1,59 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <array>
+#include <map>
+#include <memory>
+#include <thread>
+
+namespace Core {
+
+class Cpu;
+class CpuBarrier;
+class ExclusiveMonitor;
+class System;
+
+class CpuCoreManager {
+public:
+    CpuCoreManager();
+    CpuCoreManager(const CpuCoreManager&) = delete;
+    CpuCoreManager(CpuCoreManager&&) = delete;
+
+    ~CpuCoreManager();
+
+    CpuCoreManager& operator=(const CpuCoreManager&) = delete;
+    CpuCoreManager& operator=(CpuCoreManager&&) = delete;
+
+    void Initialize(System& system);
+    void Shutdown();
+
+    Cpu& GetCore(std::size_t index);
+    const Cpu& GetCore(std::size_t index) const;
+
+    Cpu& GetCurrentCore();
+    const Cpu& GetCurrentCore() const;
+
+    ExclusiveMonitor& GetExclusiveMonitor();
+    const ExclusiveMonitor& GetExclusiveMonitor() const;
+
+    void RunLoop(bool tight_loop);
+
+    void InvalidateAllInstructionCaches();
+
+private:
+    static constexpr std::size_t NUM_CPU_CORES = 4;
+
+    std::unique_ptr<ExclusiveMonitor> exclusive_monitor;
+    std::unique_ptr<CpuBarrier> barrier;
+    std::array<std::unique_ptr<Cpu>, NUM_CPU_CORES> cores;
+    std::array<std::unique_ptr<std::thread>, NUM_CPU_CORES - 1> core_threads;
+    std::size_t active_core{}; ///< Active core, only used in single thread mode
+
+    /// Map of guest threads to CPU cores
+    std::map<std::thread::id, Cpu*> thread_to_cpu;
+};
+
+} // namespace Core


### PR DESCRIPTION
Keeps the CPU-specific behavior from being spread throughout the main
System class. This will also act as the home to contain member functions
that perform operations on all cores. The reason for this being that the
following pattern is sort of prevalent throughout sections of the
codebase:

If clearing the instruction cache for all 4 cores is necessary:

Core::System::GetInstance().ArmInterface(0).ClearInstructionCache();
Core::System::GetInstance().ArmInterface(1).ClearInstructionCache();
Core::System::GetInstance().ArmInterface(2).ClearInstructionCache();
Core::System::GetInstance().ArmInterface(3).ClearInstructionCache();

This is kind of... well, silly to copy around whenever it's needed.
especially when it can be reduced down to a single line.

This change also puts the basics in place to begin "ungrafting" all of the
forwarding member functions from the System class that are used to
access CPU state or invoke CPU-specific behavior. As such, this change
itself makes no changes to the direct external interface of System. This
will be covered by another changeset.